### PR TITLE
Add Japan GSI Topo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The mapsources are based on the [MOBAC XML MapSource Format](http://mobac.source
 * World
   * Google Road: **works**
   * Google Terrain: **works**
+  * GSI Japan Topos: **works** (Note that GSI serves tiles for whole world but that detailed tiles are only served for Japan itself.)
   * Komoot: **works**
   * OSM Mapnik: **works**
   * Strava Heatmap: **doesn't work** (Tile download relies on cookie which is not available from Google Earth. Maybe possible with [API](http://strava.github.io/api/v3/heatmaps/)?

--- a/geos/world/japan_gsi_go_topo.xml
+++ b/geos/world/japan_gsi_go_topo.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<customMapSource>
+    <name>GSI Japan Topo</name>
+    <id>gsi_go_japan_topo</id>
+    <folder>world/Japan</folder>  
+    <minZoom>0</minZoom>
+    <maxZoom>18</maxZoom>
+    <tileType>png</tileType>
+    <url>http://maps.gsi.go.jp/xyz/std/{$z}/{$x}/{$y}.png</url>
+</customMapSource>


### PR DESCRIPTION
Adds Japan coverage using the Japan GSI Topo map tile server. Has global coverage at low Zoom level so have not region trimmed.